### PR TITLE
PostCreate Bugfix + Returned onclick

### DIFF
--- a/Scrumptious/posts/templates/makepost.html
+++ b/Scrumptious/posts/templates/makepost.html
@@ -18,7 +18,7 @@
                             </div>
                         {% endfor %}
                         <div class="flex justify-between items-center">
-                            <button type="submit" class="bg-primary text-white p-2 rounded">Create</button>
+                            <button type="submit" class="bg-primary text-white p-2 rounded" onclick="return alert('Post created successfully!')">Create</button>
                         </div>
                     </div>
                 </form>

--- a/Scrumptious/posts/views.py
+++ b/Scrumptious/posts/views.py
@@ -1,7 +1,5 @@
 from django.shortcuts import render, redirect
 from .forms import MakePost
-from django.contrib.auth.models import User
-
 
 def home_view(request):
     context = {}


### PR DESCRIPTION
Returned the onclick function to HTML page as we're already checking for required fields through Django. And I don't see a better way to implement this without (most likely) difficult javascript.

ForeignKey bug can be fixed through a simple database migration.

Note: New post images seem to break if you re-use the image a second time, might be worth checking out.